### PR TITLE
fix: don’t use python -m for Poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Reflux is a third-party tool for creating and publishing site-wide style themes 
 |Manager          |Command                                       |
 |:----------------|:---------------------------------------------|
 |**pip**          |`pip install reflux`                          |
-|**poetry**       |`python -m poetry add reflux`                 |
+|**poetry**       |`poetry add reflux`                 |
 |**replit**       |Search `reflux` in the Packages tab and `+` it|
 
 ### Documentation


### PR DESCRIPTION
Poetry is not meant to be installed through PIP. (See [their docs on it](https://python-poetry.org/docs/#alternative-installation-methods-not-recommended).) It is recommended instead to use their installer, which registers their command to PATH.